### PR TITLE
Make WOFF2 support optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ env:
 
 jobs:
   test-linux:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-32
     steps:
       - uses: actions/checkout@v4
 
@@ -51,7 +51,7 @@ jobs:
         run: cargo nextest run --lib
 
   test-windows:
-    runs-on: windows-latest
+    runs-on: depot-windows-2022
     steps:
       - uses: actions/checkout@v4
 
@@ -69,7 +69,7 @@ jobs:
         run: cargo nextest run --lib
 
   clippy:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-32
     steps:
       - uses: actions/checkout@v4
 
@@ -85,7 +85,7 @@ jobs:
         run: cargo clippy -p fontcull -p fontcull-cli --all-targets
 
   fmt:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-32
     steps:
       - uses: actions/checkout@v4
 
@@ -98,7 +98,7 @@ jobs:
         run: cargo fmt --all -- --check
 
   docs:
-    runs-on: depot-ubuntu-24.04-16
+    runs-on: depot-ubuntu-24.04-32
     steps:
       - uses: actions/checkout@v4
 

--- a/fontcull/Cargo.toml
+++ b/fontcull/Cargo.toml
@@ -12,16 +12,19 @@ categories = ["text-processing", "web-programming"]
 readme = "README.md"
 
 [features]
-default = []
+default = ["woff2"]
+woff2 = ["dep:woofwoof"]
 static-analysis = ["dep:scraper"]
 
 [dependencies]
 # Static HTML/CSS analysis (optional)
 scraper = { version = "0.24", optional = true }
 
+# WOFF2 compression/decompression (optional, requires C++)
+woofwoof = { version = "1.0", optional = true }
+
 # klippa backend (vendored from googlefonts/fontations)
 fontcull-klippa = { version = "0.1.2", path = "../vendored/fontcull-klippa" }
 fontcull-skrifa = { version = "0.39.2", path = "../vendored/fontcull-skrifa" }
 fontcull-write-fonts = { version = "0.44.3", path = "../vendored/fontcull-write-fonts" }
 fontcull-read-fonts = { version = "0.38.0", path = "../vendored/fontcull-read-fonts" }
-woofwoof = "1.0"

--- a/fontcull/README.md
+++ b/fontcull/README.md
@@ -8,6 +8,21 @@ Font subsetting library. Subset fonts to only include glyphs that are actually u
 - **Multiple formats** - Supports TTF, OTF, and WOFF2 input
 - **WOFF2 output** - Compress subsetted fonts to WOFF2 for web delivery
 - **Static analysis** (optional) - Parse HTML/CSS to detect font usage
+- **Optional WOFF2** - Disable for pure Rust builds without C++ dependency
+
+## Feature flags
+
+| Feature | Default | Description |
+|---------|---------|-------------|
+| `woff2` | Yes | WOFF2 compression/decompression (requires C++) |
+| `static-analysis` | No | HTML/CSS parsing for font usage detection |
+
+For a pure Rust build without WOFF2 support:
+
+```toml
+[dependencies]
+fontcull = { version = "2", default-features = false }
+```
 
 ## Usage
 
@@ -73,14 +88,14 @@ if let Some(chars) = analysis.chars_per_font.get("MyFont") {
 ### Core functions
 
 - `subset_font_data(font_data, chars)` - Subset font to TTF bytes
+- `subset_font_data_unicode(font_data, unicodes)` - Subset using `u32` codepoints
+
+### WOFF2 functions (requires `woff2` feature)
+
 - `subset_font_to_woff2(font_data, chars)` - Subset and compress to WOFF2
+- `subset_font_to_woff2_unicode(font_data, unicodes)` - Subset to WOFF2 using codepoints
 - `decompress_font(font_data)` - Decompress WOFF2 to TTF/OTF
 - `compress_to_woff2(font_data)` - Compress TTF/OTF to WOFF2
-
-### Unicode codepoint variants
-
-- `subset_font_data_unicode(font_data, unicodes)` - Subset using `u32` codepoints
-- `subset_font_to_woff2_unicode(font_data, unicodes)` - Subset to WOFF2 using codepoints
 
 ### Format detection
 

--- a/fontcull/README.md
+++ b/fontcull/README.md
@@ -26,7 +26,7 @@ fontcull = { version = "2", default-features = false }
 
 ## Usage
 
-```rust
+```ignore
 use fontcull::{subset_font_to_woff2, decompress_font};
 use std::collections::HashSet;
 
@@ -43,7 +43,7 @@ std::fs::write("MyFont-subset.woff2", woff2).unwrap();
 
 ### With WOFF2 input
 
-```rust
+```ignore
 use fontcull::{decompress_font, subset_font_data, compress_to_woff2};
 use std::collections::HashSet;
 
@@ -65,7 +65,7 @@ Enable the `static-analysis` feature to parse HTML and CSS for font usage:
 fontcull = { version = "2", features = ["static-analysis"] }
 ```
 
-```rust
+```ignore
 use fontcull::{analyze_fonts, extract_css_from_html, subset_font_to_woff2};
 
 let html = r#"<html>

--- a/fontcull/src/lib.rs
+++ b/fontcull/src/lib.rs
@@ -78,13 +78,16 @@ impl FontFormat {
     }
 }
 
-/// Decompress a WOFF font to TTF/OTF
+/// Decompress a WOFF2 font to TTF/OTF
 ///
 /// If the input is already TTF/OTF, returns a copy unchanged.
-/// If the input is WOFF1 or WOFF2, decompresses it to TTF/OTF.
+/// If the input is WOFF2, decompresses it to TTF/OTF.
 ///
 /// This is a separate operation that can be cached/salsified independently
 /// from subsetting.
+///
+/// Requires the `woff2` feature (enabled by default).
+#[cfg(feature = "woff2")]
 pub fn decompress_font(font_data: &[u8]) -> Result<Vec<u8>, SubsetError> {
     match FontFormat::detect(font_data) {
         FontFormat::Woff2 => woofwoof::decompress(font_data)
@@ -103,6 +106,9 @@ pub fn decompress_font(font_data: &[u8]) -> Result<Vec<u8>, SubsetError> {
 ///
 /// This is a separate operation that can be cached/salsified independently
 /// from subsetting.
+///
+/// Requires the `woff2` feature (enabled by default).
+#[cfg(feature = "woff2")]
 pub fn compress_to_woff2(font_data: &[u8]) -> Result<Vec<u8>, SubsetError> {
     // woofwoof::compress(data, metadata, quality, allow_transforms)
     // - metadata: empty string (no metadata)
@@ -161,6 +167,9 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
 ///
 /// Takes raw font data and a set of characters,
 /// returns the subsetted font as WOFF2 bytes.
+///
+/// Requires the `woff2` feature (enabled by default).
+#[cfg(feature = "woff2")]
 pub fn subset_font_to_woff2(
     font_data: &[u8],
     chars: &HashSet<char>,
@@ -216,6 +225,9 @@ pub fn subset_font_data_unicode(
 }
 
 /// Subset a font to WOFF2 using unicode codepoints (u32)
+///
+/// Requires the `woff2` feature (enabled by default).
+#[cfg(feature = "woff2")]
 pub fn subset_font_to_woff2_unicode(
     font_data: &[u8],
     unicodes: &[u32],
@@ -280,6 +292,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "woff2")]
     fn test_decompress_ttf_passthrough() {
         // A minimal valid-ish TTF header (just for format detection)
         let ttf_data = [0x00, 0x01, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00];
@@ -288,6 +301,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "woff2")]
     fn test_decompress_woff2_fixture() {
         // Read WOFF2 fixture file (created by fonttools)
         let woff2_data =
@@ -308,6 +322,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "woff2")]
     fn test_decompress_woff1_not_supported() {
         // Read WOFF1 fixture file (created by fonttools)
         let woff1_data =
@@ -322,6 +337,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "woff2")]
     fn test_subset_woff2_input() {
         // Read WOFF2 fixture
         let woff2_input =


### PR DESCRIPTION
## Summary

- Add `woff2` feature flag (enabled by default) to gate WOFF2 compression/decompression
- When disabled, fontcull compiles without the `woofwoof` C++ dependency
- Core subsetting functions (`subset_font_data`, `subset_font_data_unicode`) remain available
- Upgrade CI runners to depot 32-core Ubuntu and depot Windows

## Changes

### fontcull crate
- `woff2` feature added to default features
- `woofwoof` dependency made optional
- Functions gated behind `woff2` feature:
  - `decompress_font()`
  - `compress_to_woff2()`
  - `subset_font_to_woff2()`
  - `subset_font_to_woff2_unicode()`

### CI
- Linux: 16 → 32 cores
- Windows: GitHub default → depot-windows-2022

## Usage

Pure Rust build (no WOFF2, no C++):
```toml
fontcull = { version = "2", default-features = false }
```

Closes #12

## Test plan

- [x] `cargo check -p fontcull --no-default-features` compiles
- [x] `cargo check` (full workspace) compiles
- [x] `cargo test -p fontcull` passes (7 tests)
- [x] `cargo test -p fontcull --no-default-features` passes (3 tests, WOFF2 tests skipped)