### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fontcull"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "fontcull-klippa",
  "fontcull-read-fonts",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fontcull-cli"
-version = "1.0.5"
+version = "1.0.6"
 dependencies = [
  "chromiumoxide",
  "clap 4.5.53",

--- a/fontcull-cli/CHANGELOG.md
+++ b/fontcull-cli/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.6](https://github.com/bearcove/fontcull/compare/fontcull-cli-v1.0.5...fontcull-cli-v1.0.6) - 2026-01-23
+
+### Other
+
+- Include a default set of OpenType layout tables, allow specifying extra OpenType features to include in subset ([#20](https://github.com/bearcove/fontcull/pull/20))
+- Add README files for both crates ([#11](https://github.com/bearcove/fontcull/pull/11))
+
 ## [1.0.5](https://github.com/bearcove/fontcull/releases/tag/fontcull-cli-v1.0.5) - 2025-12-03
 
 ### Other

--- a/fontcull-cli/Cargo.toml
+++ b/fontcull-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontcull-cli"
-version = "1.0.5"
+version = "1.0.6"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 description = "CLI tool to subset fonts based on actual glyph usage from web pages"
@@ -22,7 +22,7 @@ name = "fontcull"
 path = "src/main.rs"
 
 [dependencies]
-fontcull = { version = "2.0.0", path = "../fontcull" }
+fontcull = { version = "2.0.1", path = "../fontcull" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/fontcull/CHANGELOG.md
+++ b/fontcull/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.1](https://github.com/bearcove/fontcull/compare/fontcull-v2.0.0...fontcull-v2.0.1) - 2026-01-23
+
+### Other
+
+- Include a default set of OpenType layout tables, allow specifying extra OpenType features to include in subset ([#20](https://github.com/bearcove/fontcull/pull/20))
+- Make WOFF2 support optional ([#14](https://github.com/bearcove/fontcull/pull/14))
+- Add README files for both crates ([#11](https://github.com/bearcove/fontcull/pull/11))
+
 ## [2.0.0](https://github.com/bearcove/fontcull/compare/fontcull-v1.0.5...fontcull-v2.0.0) - 2025-12-03
 
 ### Other

--- a/fontcull/Cargo.toml
+++ b/fontcull/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontcull"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 description = "Pure Rust font subsetting library"


### PR DESCRIPTION



## 🤖 New release

* `fontcull`: 2.0.0 -> 2.0.1 (✓ API compatible changes)
* `fontcull-cli`: 1.0.5 -> 1.0.6

<details><summary><i><b>Changelog</b></i></summary><p>

## `fontcull`

<blockquote>

## [2.0.1](https://github.com/bearcove/fontcull/compare/fontcull-v2.0.0...fontcull-v2.0.1) - 2026-01-23

### Other

- Include a default set of OpenType layout tables, allow specifying extra OpenType features to include in subset ([#20](https://github.com/bearcove/fontcull/pull/20))
- Make WOFF2 support optional ([#14](https://github.com/bearcove/fontcull/pull/14))
- Add README files for both crates ([#11](https://github.com/bearcove/fontcull/pull/11))
</blockquote>

## `fontcull-cli`

<blockquote>

## [1.0.6](https://github.com/bearcove/fontcull/compare/fontcull-cli-v1.0.5...fontcull-cli-v1.0.6) - 2026-01-23

### Other

- Include a default set of OpenType layout tables, allow specifying extra OpenType features to include in subset ([#20](https://github.com/bearcove/fontcull/pull/20))
- Add README files for both crates ([#11](https://github.com/bearcove/fontcull/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).