### PR TITLE
Migrate from clap to facet-args

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -922,6 +922,69 @@ dependencies = [
 ]
 
 [[package]]
+name = "facet"
+version = "0.31.8"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "facet-core",
+ "facet-macros",
+ "static_assertions",
+]
+
+[[package]]
+name = "facet-args"
+version = "0.31.7"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "facet",
+ "facet-core",
+ "facet-reflect",
+ "heck 0.5.0",
+ "miette",
+ "owo-colors",
+ "tracing",
+]
+
+[[package]]
+name = "facet-core"
+version = "0.31.8"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "bitflags 2.10.0",
+ "impls",
+ "paste",
+]
+
+[[package]]
+name = "facet-macros"
+version = "0.31.8"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "facet-core",
+ "facet-macros-impl",
+]
+
+[[package]]
+name = "facet-macros-impl"
+version = "0.31.8"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "unsynn",
+]
+
+[[package]]
+name = "facet-reflect"
+version = "0.31.8"
+source = "git+https://github.com/facet-rs/facet#9f5978028ed1e13d803b1c1419ad7a67eb8eb1fa"
+dependencies = [
+ "facet-core",
+ "facet-macros",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -962,8 +1025,9 @@ name = "fontcull-cli"
 version = "1.0.5"
 dependencies = [
  "chromiumoxide",
- "clap 4.5.53",
  "color-eyre",
+ "facet",
+ "facet-args",
  "fontcull",
  "futures",
  "glob",
@@ -1507,6 +1571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "impls"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a46645bbd70538861a90d0f26c31537cdf1e44aae99a794fb75a664b70951bc"
+
+[[package]]
 name = "indenter"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1711,6 +1781,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "miette"
+version = "7.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f98efec8807c63c752b5bd61f862c165c115b0a35685bdcfd9238c7aeb592b7"
+dependencies = [
+ "cfg-if",
+ "unicode-width 0.1.14",
+]
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1729,6 +1809,12 @@ dependencies = [
  "wasi",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "mutants"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc0287524726960e07b119cebd01678f852f147742ae0d925e6a520dca956126"
 
 [[package]]
 name = "new_debug_unreachable"
@@ -1815,6 +1901,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -2214,6 +2306,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
 name = "rustc_version"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2555,12 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "string_cache"
@@ -2801,6 +2905,17 @@ name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unsynn"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "501a7adf1a4bd9951501e5c66621e972ef8874d787628b7f90e64f936ef7ec0a"
+dependencies = [
+ "mutants",
+ "proc-macro2",
+ "rustc-hash",
+]
 
 [[package]]
 name = "url"

--- a/fontcull-cli/Cargo.toml
+++ b/fontcull-cli/Cargo.toml
@@ -24,7 +24,8 @@ path = "src/main.rs"
 fontcull = { version = "2.0.0", path = "../fontcull" }
 
 # CLI dependencies
-clap = { version = "4", features = ["derive"] }
+facet = { git = "https://github.com/facet-rs/facet" }
+facet-args = { git = "https://github.com/facet-rs/facet" }
 glob = "0.3"
 color-eyre = "0.6"
 tracing = "0.1"

--- a/fontcull-cli/src/main.rs
+++ b/fontcull-cli/src/main.rs
@@ -1,39 +1,39 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use chromiumoxide::{Page, browser::Browser};
-use clap::Parser;
 use color_eyre::eyre::{Context, Result};
+use facet::Facet;
+use facet_args as args;
 use futures::StreamExt;
 
 mod glyph_script;
 mod klippa_backend;
 
-#[derive(Parser, Debug)]
-#[command(name = "fontcull")]
-#[command(about = "Subset fonts based on actual glyph usage from web pages")]
+/// Subset fonts based on actual glyph usage from web pages
+#[derive(Facet, Debug)]
 struct Args {
     /// URLs to scan for glyph usage
-    #[arg(required = true)]
+    #[facet(args::positional)]
     urls: Vec<String>,
 
     /// Font files to subset (glob patterns supported)
-    #[arg(long, short = 's')]
+    #[facet(default, args::named, args::short = 's')]
     subset: Vec<String>,
 
     /// Only include glyphs used by these font families (comma-separated)
-    #[arg(long, short = 'f')]
+    #[facet(default, args::named, args::short = 'f')]
     family: Option<String>,
 
     /// Maximum number of pages to spider (0 = no limit)
-    #[arg(long, default_value = "0")]
+    #[facet(default = 0, args::named)]
     spider_limit: usize,
 
     /// Additional characters to always include (whitelist)
-    #[arg(long, short = 'w')]
+    #[facet(default, args::named, args::short = 'w')]
     whitelist: Option<String>,
 
     /// Output directory for subset fonts
-    #[arg(long, short = 'o')]
+    #[facet(default, args::named, args::short = 'o')]
     output: Option<PathBuf>,
 }
 
@@ -249,7 +249,19 @@ async fn main() -> Result<()> {
         )
         .init();
 
-    let args = Args::parse();
+    // Handle --help before parsing
+    let raw_args: Vec<String> = std::env::args().skip(1).collect();
+    if raw_args.iter().any(|a| a == "--help" || a == "-h") {
+        let help = args::help::generate_help::<Args>(&args::help::HelpConfig {
+            program_name: Some("fontcull".to_string()),
+            version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            ..Default::default()
+        });
+        println!("{help}");
+        return Ok(());
+    }
+
+    let args: Args = args::from_std_args()?;
     tracing::info!(?args, "Starting fontcull");
 
     // Launch browser


### PR DESCRIPTION
## Summary
- Replace clap derive macros with facet-args for CLI argument parsing
- Use git dependencies since the published version doesn't export the help module yet
- Manual --help handling added since facet-args doesn't intercept it automatically

Closes #13

## Test plan
- [x] `cargo build --package fontcull-cli` compiles successfully
- [x] `fontcull --help` displays help text
- [x] `fontcull --unknown` shows error for unknown flags