### PR TITLE
Include a default set of OpenType layout tables, allow specifying extra OpenType features to include in subset

### DIFF
--- a/fontcull-cli/src/klippa_backend.rs
+++ b/fontcull-cli/src/klippa_backend.rs
@@ -3,9 +3,10 @@ use std::path::PathBuf;
 use color_eyre::eyre::{Context, Result};
 
 /// Subset a font using klippa (pure Rust, no external dependencies)
-pub fn subset_with_klippa(
+pub fn subset_with_klippa<'a>(
     font_path: &str,
     unicodes: &[u32],
+    opentype_features: &[[u8; 4]],
     output_dir: Option<&PathBuf>,
 ) -> Result<PathBuf> {
     let path = PathBuf::from(font_path);
@@ -25,8 +26,9 @@ pub fn subset_with_klippa(
         fontcull::decompress_font(&font_data).map_err(|e| color_eyre::eyre::eyre!("{}", e))?;
 
     // Subset and compress to WOFF2
-    let woff2_data = fontcull::subset_font_to_woff2_unicode(&decompressed, unicodes)
-        .map_err(|e| color_eyre::eyre::eyre!("{}", e))?;
+    let woff2_data =
+        fontcull::subset_font_to_woff2_unicode(&decompressed, unicodes, opentype_features)
+            .map_err(|e| color_eyre::eyre::eyre!("{}", e))?;
 
     // Write the woff2 file
     std::fs::write(&output_path, &woff2_data)

--- a/fontcull-cli/src/main.rs
+++ b/fontcull-cli/src/main.rs
@@ -3,8 +3,9 @@
 use std::{collections::HashMap, path::PathBuf};
 
 use chromiumoxide::{Page, browser::Browser};
-use clap::Parser;
+use clap::{Parser, builder::NonEmptyStringValueParser};
 use color_eyre::eyre::{Context, Result};
+use fontcull::OpenTypeFeatureTag;
 use futures::StreamExt;
 
 mod glyph_script;
@@ -34,9 +35,63 @@ struct Args {
     #[arg(long, short = 'w')]
     whitelist: Option<String>,
 
+    /// OpenType features to include in the subset (comma-separated)
+    #[arg(long, value_delimiter = ',', value_parser = OpenTypeFeatureParser::new())]
+    opentype_features: Vec<OpenTypeFeatureTag>,
+
     /// Output directory for subset fonts
     #[arg(long, short = 'o')]
     output: Option<PathBuf>,
+}
+
+/// Parse OpenType feature tags.
+///
+/// OpenType feature tags are 4-character long ASCII alphanumeric strings.
+/// Examples include `calt` (Contextual Alternates), `c2sc` (Small Capitals from Capitals)
+/// and `ss01` (Stylistic Set 1).
+#[derive(Copy, Clone, Debug)]
+struct OpenTypeFeatureParser {
+    base_parser: NonEmptyStringValueParser,
+}
+
+impl OpenTypeFeatureParser {
+    /// Parse 4-character opentype features
+    pub fn new() -> Self {
+        Self {
+            base_parser: NonEmptyStringValueParser::new(),
+        }
+    }
+}
+
+impl clap::builder::TypedValueParser for OpenTypeFeatureParser {
+    type Value = OpenTypeFeatureTag;
+
+    fn parse_ref(
+        &self,
+        cmd: &clap::Command,
+        arg: Option<&clap::Arg>,
+        value: &std::ffi::OsStr,
+    ) -> std::result::Result<OpenTypeFeatureTag, clap::Error> {
+        use clap::error::{Error, ErrorKind};
+
+        let base_result = self.base_parser.parse_ref(cmd, arg, value)?;
+
+        if base_result.len() != 4 {
+            return Err(Error::raw(
+                ErrorKind::ValueValidation,
+                format!("OpenType feature '{base_result}' must be a 4 character string"),
+            ));
+        }
+
+        if !base_result.chars().all(|c| c.is_ascii_alphanumeric()) {
+            return Err(Error::raw(
+                ErrorKind::ValueValidation,
+                format!("OpenType feature '{base_result}' must be an ASCII alphanumeric string"),
+            ));
+        }
+
+        Ok(base_result.as_bytes().try_into().unwrap())
+    }
 }
 
 /// Character set per font-family, plus a universal "*" set
@@ -336,8 +391,12 @@ async fn main() -> Result<()> {
         for font_file in font_files {
             tracing::info!("Subsetting font: {}", font_file);
 
-            let output =
-                klippa_backend::subset_with_klippa(&font_file, &chars, args.output.as_ref())?;
+            let output = klippa_backend::subset_with_klippa(
+                &font_file,
+                &chars,
+                &args.opentype_features,
+                args.output.as_ref(),
+            )?;
 
             tracing::info!("Created: {}", output.display());
         }

--- a/fontcull/src/lib.rs
+++ b/fontcull/src/lib.rs
@@ -24,6 +24,8 @@ pub enum SubsetError {
     WoffDecompress(String),
 }
 
+pub type OpenTypeFeatureTag = [u8; 4];
+
 impl std::fmt::Display for SubsetError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -121,17 +123,28 @@ pub fn compress_to_woff2(font_data: &[u8]) -> Result<Vec<u8>, SubsetError> {
         .ok_or_else(|| SubsetError::Woff2("WOFF2 compression failed".to_string()))
 }
 
-fn layout_features() -> IntSet<Tag> {
+fn layout_features(extra_features: &[OpenTypeFeatureTag]) -> IntSet<Tag> {
     use fontcull_klippa::DEFAULT_LAYOUT_FEATURES;
 
-    IntSet::from_iter(DEFAULT_LAYOUT_FEATURES.iter().copied())
+    let extra_feature_tags = extra_features.iter().map(|ft| Tag::new(ft));
+
+    IntSet::from_iter(
+        DEFAULT_LAYOUT_FEATURES
+            .iter()
+            .copied()
+            .chain(extra_feature_tags),
+    )
 }
 
 /// Subset a font to only include the specified characters
 ///
 /// Takes raw font data (TTF/OTF/WOFF/WOFF2) and a set of characters,
 /// returns the subsetted font as TTF bytes.
-pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u8>, SubsetError> {
+pub fn subset_font_data(
+    font_data: &[u8],
+    chars: &HashSet<char>,
+    opentype_features: &[OpenTypeFeatureTag],
+) -> Result<Vec<u8>, SubsetError> {
     use fontcull_klippa::{Plan, SubsetFlags, subset_font};
     use fontcull_skrifa::{FontRef, GlyphId};
     use fontcull_write_fonts::types::NameId;
@@ -152,7 +165,7 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
     let empty_langs: IntSet<u16> = IntSet::empty();
 
     let layout_scripts: IntSet<Tag> = IntSet::all();
-    let layout_features: IntSet<Tag> = layout_features();
+    let layout_features: IntSet<Tag> = layout_features(opentype_features);
 
     // Create subsetting plan
     let plan = Plan::new(
@@ -160,11 +173,11 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
         &unicodes,   // unicode codepoints to keep
         &font,
         SubsetFlags::default(),
-        &empty_tags,     // tables to drop
-        &layout_scripts,        // layout scripts
-        &layout_features,       // layout features
-        &empty_name_ids, // name IDs
-        &empty_langs,    // name languages
+        &empty_tags,      // tables to drop
+        &layout_scripts,  // layout scripts
+        &layout_features, // layout features
+        &empty_name_ids,  // name IDs
+        &empty_langs,     // name languages
     );
 
     // Perform subsetting
@@ -184,8 +197,9 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
 pub fn subset_font_to_woff2(
     font_data: &[u8],
     chars: &HashSet<char>,
+    opentype_features: &[OpenTypeFeatureTag],
 ) -> Result<Vec<u8>, SubsetError> {
-    let subsetted = subset_font_data(font_data, chars)?;
+    let subsetted = subset_font_data(font_data, chars, opentype_features)?;
 
     // Compress to WOFF2
     let woff2 = woofwoof::compress(&subsetted, "", 11, true)
@@ -200,6 +214,7 @@ pub fn subset_font_to_woff2(
 pub fn subset_font_data_unicode(
     font_data: &[u8],
     unicodes: &[u32],
+    opentype_features: &[OpenTypeFeatureTag],
 ) -> Result<Vec<u8>, SubsetError> {
     use fontcull_klippa::{Plan, SubsetFlags, subset_font};
     use fontcull_read_fonts::collections::IntSet;
@@ -219,7 +234,7 @@ pub fn subset_font_data_unicode(
     let empty_langs: IntSet<u16> = IntSet::empty();
 
     let layout_scripts: IntSet<Tag> = IntSet::all();
-    let layout_features: IntSet<Tag> = layout_features();
+    let layout_features: IntSet<Tag> = layout_features(opentype_features);
 
     let plan = Plan::new(
         &empty_gids,
@@ -245,8 +260,9 @@ pub fn subset_font_data_unicode(
 pub fn subset_font_to_woff2_unicode(
     font_data: &[u8],
     unicodes: &[u32],
+    opentype_features: &[OpenTypeFeatureTag],
 ) -> Result<Vec<u8>, SubsetError> {
-    let subsetted = subset_font_data_unicode(font_data, unicodes)?;
+    let subsetted = subset_font_data_unicode(font_data, unicodes, opentype_features)?;
 
     let woff2 = woofwoof::compress(&subsetted, "", 11, true)
         .ok_or_else(|| SubsetError::Woff2("WOFF2 compression failed".to_string()))?;
@@ -332,7 +348,7 @@ mod tests {
 
         // And we should be able to subset it
         let chars: HashSet<char> = ['a', 'b', 'c'].into_iter().collect();
-        let _subsetted = subset_font_data(&decompressed, &chars).expect("failed to subset");
+        let _subsetted = subset_font_data(&decompressed, &chars, &[]).expect("failed to subset");
     }
 
     #[test]
@@ -360,7 +376,7 @@ mod tests {
         // Decompress, subset, and recompress - the full pipeline
         let decompressed = decompress_font(&woff2_input).expect("failed to decompress");
         let chars: HashSet<char> = ['a', 'b', 'c'].into_iter().collect();
-        let subsetted = subset_font_data(&decompressed, &chars).expect("failed to subset");
+        let subsetted = subset_font_data(&decompressed, &chars, &[]).expect("failed to subset");
         let woff2_output = compress_to_woff2(&subsetted).expect("failed to compress output");
 
         // Verify output is WOFF2

--- a/fontcull/src/lib.rs
+++ b/fontcull/src/lib.rs
@@ -2,6 +2,9 @@
 
 use std::collections::HashSet;
 
+use fontcull_read_fonts::collections::IntSet;
+use fontcull_skrifa::Tag;
+
 #[cfg(feature = "static-analysis")]
 mod static_analysis;
 
@@ -118,14 +121,19 @@ pub fn compress_to_woff2(font_data: &[u8]) -> Result<Vec<u8>, SubsetError> {
         .ok_or_else(|| SubsetError::Woff2("WOFF2 compression failed".to_string()))
 }
 
+fn layout_features() -> IntSet<Tag> {
+    use fontcull_klippa::DEFAULT_LAYOUT_FEATURES;
+
+    IntSet::from_iter(DEFAULT_LAYOUT_FEATURES.iter().copied())
+}
+
 /// Subset a font to only include the specified characters
 ///
 /// Takes raw font data (TTF/OTF/WOFF/WOFF2) and a set of characters,
 /// returns the subsetted font as TTF bytes.
 pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u8>, SubsetError> {
     use fontcull_klippa::{Plan, SubsetFlags, subset_font};
-    use fontcull_read_fonts::collections::IntSet;
-    use fontcull_skrifa::{FontRef, GlyphId, Tag};
+    use fontcull_skrifa::{FontRef, GlyphId};
     use fontcull_write_fonts::types::NameId;
 
     // Parse the font
@@ -143,6 +151,9 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
     let empty_name_ids: IntSet<NameId> = IntSet::empty();
     let empty_langs: IntSet<u16> = IntSet::empty();
 
+    let layout_scripts: IntSet<Tag> = IntSet::all();
+    let layout_features: IntSet<Tag> = layout_features();
+
     // Create subsetting plan
     let plan = Plan::new(
         &empty_gids, // glyph IDs - not needed when using unicodes
@@ -150,8 +161,8 @@ pub fn subset_font_data(font_data: &[u8], chars: &HashSet<char>) -> Result<Vec<u
         &font,
         SubsetFlags::default(),
         &empty_tags,     // tables to drop
-        &empty_tags,     // layout scripts
-        &empty_tags,     // layout features
+        &layout_scripts,        // layout scripts
+        &layout_features,       // layout features
         &empty_name_ids, // name IDs
         &empty_langs,    // name languages
     );
@@ -207,14 +218,17 @@ pub fn subset_font_data_unicode(
     let empty_name_ids: IntSet<NameId> = IntSet::empty();
     let empty_langs: IntSet<u16> = IntSet::empty();
 
+    let layout_scripts: IntSet<Tag> = IntSet::all();
+    let layout_features: IntSet<Tag> = layout_features();
+
     let plan = Plan::new(
         &empty_gids,
         &unicode_set,
         &font,
         SubsetFlags::default(),
         &empty_tags,
-        &empty_tags,
-        &empty_tags,
+        &layout_scripts,
+        &layout_features,
         &empty_name_ids,
         &empty_langs,
     );


### PR DESCRIPTION
# Summary

* Fixed subtle readability issues and issues with font layouting for non-latin scripts (RTL, CJK etc) by including a number of OpenType layout tables in the font subset (eg. kerning, default ligatures like 'fi', 'ft').
* Implemented feature to include extra OpenType features. Eg. small capitals, stylistic sets, discretionary ligatures. Added `--opentype-features` flag to `fontcull-cli`.

# Future work

* Detect opentype features with static analysis (check for `font-feature-settings` and `font-variant-*` CSS properties).
* Add test for opentype features (need to read generated font and check font tables).

# Impact

* Font layout and rendering as meant by the font's author is maintained.
* Can now use extra font features.

# Description

Most fonts come with kerning rules that affect the spacing between character combinations chosen by the author. Examples: **AV**, **Va**, **Tata**. Observe how there is some space "taken" from A, V and T for the subsequent glyphs.

Additionally, fonts for non-latin scripts need even more layout rules, for example for right-to-left scripts, or for CJK.

This pull request makes it so that a number of predefined layout tables are included in the subsetted fonts. The table names are already exported as a constant in Klippa. They were taken from Harbuzz, which in part took them from fontutils.

On top of that, given that I needed to deal with OpenType features to fix this issue, I figured that it would be extra nice to add the ability to `fontcull` and `fontcull-cli` to specify OpenType features to retain. This allows to retain things like small capitals, stylistic sets, discretionary ligatures etc. Only the used glyphs _should_ be retained, so even with all these features enabled, the end result should still be a drastically smaller font. To try this out with `fontcull-cli`, you can use the `--opentype-features` flag. To include small capitals and oldstyle numerals for example: `--opentype-features "smcp,onum"`.

You can inspect font features on this website: [Wakamai Fondue](https://wakamaifondue.com/beta/). Example output for a non-subsetted Fira Sans:

<img width="1756" height="2806" alt="image" src="https://github.com/user-attachments/assets/5b089e7e-9d95-4d8d-a41c-20fc74acae48" />

And here is a subsetted variant for my website, with layout tables included and some opentype features (small capitals, {oldstyle, tabular, proportional numerals}):

<img width="1758" height="1881" alt="image" src="https://github.com/user-attachments/assets/78b9e274-af58-4f1c-8da2-64fcc5f67449" />

Notice the size decrease from 289 KB to just 16 KB.
