### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -947,7 +947,7 @@ checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "fontcull"
-version = "2.0.1"
+version = "2.0.2"
 dependencies = [
  "fontcull-klippa",
  "fontcull-read-fonts",
@@ -959,7 +959,7 @@ dependencies = [
 
 [[package]]
 name = "fontcull-cli"
-version = "1.0.6"
+version = "1.0.7"
 dependencies = [
  "chromiumoxide",
  "clap 4.5.53",

--- a/fontcull-cli/CHANGELOG.md
+++ b/fontcull-cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7](https://github.com/bearcove/fontcull/compare/fontcull-cli-v1.0.6...fontcull-cli-v1.0.7) - 2026-02-02
+
+### Other
+
+- updated the following local packages: fontcull
+
 ## [1.0.6](https://github.com/bearcove/fontcull/compare/fontcull-cli-v1.0.5...fontcull-cli-v1.0.6) - 2026-01-23
 
 ### Other

--- a/fontcull-cli/Cargo.toml
+++ b/fontcull-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontcull-cli"
-version = "1.0.6"
+version = "1.0.7"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 description = "CLI tool to subset fonts based on actual glyph usage from web pages"
@@ -22,7 +22,7 @@ name = "fontcull"
 path = "src/main.rs"
 
 [dependencies]
-fontcull = { version = "2.0.1", path = "../fontcull" }
+fontcull = { version = "2.0.2", path = "../fontcull" }
 
 # CLI dependencies
 clap = { version = "4", features = ["derive"] }

--- a/fontcull/CHANGELOG.md
+++ b/fontcull/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.2](https://github.com/bearcove/fontcull/compare/fontcull-v2.0.1...fontcull-v2.0.2) - 2026-02-02
+
+### Other
+
+- Make README examples compile-checked by CI
+
 ## [2.0.1](https://github.com/bearcove/fontcull/compare/fontcull-v2.0.0...fontcull-v2.0.1) - 2026-01-23
 
 ### Other

--- a/fontcull/Cargo.toml
+++ b/fontcull/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fontcull"
-version = "2.0.1"
+version = "2.0.2"
 edition = "2024"
 authors = ["Amos Wenger <amos@bearcove.eu>"]
 description = "Pure Rust font subsetting library"


### PR DESCRIPTION



## 🤖 New release

* `fontcull`: 2.0.1 -> 2.0.2 (✓ API compatible changes)
* `fontcull-cli`: 1.0.6 -> 1.0.7

<details><summary><i><b>Changelog</b></i></summary><p>

## `fontcull`

<blockquote>

## [2.0.2](https://github.com/bearcove/fontcull/compare/fontcull-v2.0.1...fontcull-v2.0.2) - 2026-02-02

### Other

- Make README examples compile-checked by CI
</blockquote>

## `fontcull-cli`

<blockquote>

## [1.0.7](https://github.com/bearcove/fontcull/compare/fontcull-cli-v1.0.6...fontcull-cli-v1.0.7) - 2026-02-02

### Other

- updated the following local packages: fontcull
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).